### PR TITLE
Refactor/logger trace extensions

### DIFF
--- a/Extensions/LoggerTraceExtensions.cs
+++ b/Extensions/LoggerTraceExtensions.cs
@@ -5,6 +5,10 @@ namespace elando.ELK.TraceLogging.Extensions
     public record LogModelWithRequestId<T>(T Model, Guid requestId);
     public record LogModelWithMessageAndTraceId<T>(string Message, LogModelWithRequestId<T>? LogModelWithRequestId);
 
+
+    /// <summary>
+    /// Extends Microsoft.Extensions.Logger.ILogger
+    /// </summary>
     public static class LoggerTraceExtensions
     {
         #region LogWithTraceId overloads
@@ -15,7 +19,6 @@ namespace elando.ELK.TraceLogging.Extensions
         /// <param name="logger"></param>
         /// <param name="model"></param>
         /// <param name="traceId"></param>
-        /// <param name="message"></param>
         /// <param name="sensitivePropertyNames"></param>
         /// <returns>New object with model and traceId.</returns>
         // - logLevel

--- a/Extensions/LoggerTraceExtensions.cs
+++ b/Extensions/LoggerTraceExtensions.cs
@@ -1,56 +1,13 @@
-﻿using elando.ELK.TraceLogging.Extensions;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
-using static elando.ELK.TraceLogging.Extensions.ObjectExtensions;
-
-namespace elando.ELK.TraceLogging.Services.Logger
+namespace elando.ELK.TraceLogging.Extensions
 {
     public record LogModelWithRequestId<T>(T Model, Guid requestId);
+    public record LogModelWithMessageAndTraceId<T>(string Message, LogModelWithRequestId<T>? LogModelWithRequestId);
 
     public static class LoggerTraceExtensions
     {
         #region LogWithTraceId overloads
-
-        /// <summary>
-        /// Logs only objects with depth-1 and if logger is not null.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="logger"></param>
-        /// <param name="model"></param>
-        /// <param name="traceId"></param>
-        /// <param name="sensitivePropertyNames"></param>
-        /// <returns>New object with model and traceId.</returns>
-        // - message - logLevel
-        public static LogModelWithRequestId<T> LogWithTraceId<T>(
-            this ILogger logger,
-            T model,
-            Guid traceId,
-            params string[] sensitivePropertyNames)
-            where T : class
-                => LogWithTraceId(logger, model, traceId, LogLevel.Information, null!, sensitivePropertyNames);
-
-
-        /// <summary>
-        /// Logs only objects with depth-1 and if logger is not null.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="logger"></param>
-        /// <param name="model"></param>
-        /// <param name="traceId"></param>
-        /// <param name="logLevel"></param>
-        /// <param name="sensitivePropertyNames"></param>
-        /// <returns>New object with model and traceId.</returns>
-        // - message
-        public static LogModelWithRequestId<T> LogWithTraceId<T>(
-            this ILogger logger,
-            T model,
-            Guid traceId,
-            LogLevel logLevel,
-            params string[] sensitivePropertyNames)
-            where T : class
-                => LogWithTraceId(logger, model, traceId, logLevel, null!, sensitivePropertyNames);
-
-
         /// <summary>
         /// Logs only objects with depth-1 and if logger is not null.
         /// </summary>
@@ -66,10 +23,9 @@ namespace elando.ELK.TraceLogging.Services.Logger
             this ILogger logger,
             T model,
             Guid traceId,
-            string message,
             params string[] sensitivePropertyNames)
             where T : class
-                => LogWithTraceId(logger, model, traceId, LogLevel.Information, message, sensitivePropertyNames);
+                => logger.LogWithTraceId(model, traceId, LogLevel.Information, sensitivePropertyNames);
 
         /// <summary>
         /// Logs only objects with depth-1 and if logger is not null.
@@ -84,15 +40,9 @@ namespace elando.ELK.TraceLogging.Services.Logger
             T model,
             Guid traceId,
             LogLevel logLevel,
-            string message = "",
             params string[] sensitivePropertyNames)
             where T : class
         {
-            if (!string.IsNullOrWhiteSpace(message))
-            {
-                message += " ";
-            }
-
             var resultWithTraceId = new LogModelWithRequestId<T>(model, traceId);
             if (logger is null)
             {
@@ -112,8 +62,7 @@ namespace elando.ELK.TraceLogging.Services.Logger
                     ? new LogModelWithRequestId<T>(requestToLog, traceId)
                     : resultWithTraceId;
 
-            var logModel = string.Format("{0}{1}", message, logModelWithTraceId.ToJSON());
-            logger.Log(logLevel, logModel);
+            logger.Log(logLevel, logModelWithTraceId.ToJSON());
 
             return resultWithTraceId;
         }


### PR DESCRIPTION
1) Renaming namespace of TraceLoggerExtensions - refactoring.
2) Removing argument: 'message' from LogWithTraceId.
        Reason: bugs overloads when we have sensitive data without message & visualization is better when the whole log is in JSON format.
        Workaround: Wrap T Model with the custom message 
             ex: var modelWithMessage = new { Message = "Custom Message", Model = model };
                  _logger.LogWithTraceId(modelWithMessage, traceId, "password")